### PR TITLE
Fix for deserializing DateTimeOffset. (Bug in YAML.net)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
    <PackageVersion_GitToolsCore>1.3.1</PackageVersion_GitToolsCore>
-   <PackageVersion_YamlDotNet>4.2.1</PackageVersion_YamlDotNet>
+   <PackageVersion_YamlDotNet>4.2.3</PackageVersion_YamlDotNet>
    <PackageVersion_LibGit2SharpNativeBinaries>[1.0.185]</PackageVersion_LibGit2SharpNativeBinaries>
  </PropertyGroup>
 </Project>


### PR DESCRIPTION
There is an issue with YAML.net under .netcore. This issue prevents the use of "ignore: commits-before" in the GitVersion.yml file. This PR updates the yaml.net package to the version in which this issue is fixed. 

Original bug against YamlDotNet:
https://github.com/aaubry/YamlDotNet/issues/293