### PR TITLE
Test project not using $(PackageVersion_YamlDotNet)

### DIFF
--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -43,7 +43,7 @@
     <packagereference Include="NUnit3TestAdapter" Version="3.9.0"></packagereference>
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.0" />
-    <PackageReference Include="YamlDotNet" Version="4.2.1" />  
+    <PackageReference Include="YamlDotNet" Version="$(PackageVersion_YamlDotNet)" />  
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="System" />


### PR DESCRIPTION
Looks like I missed this error in my last contribution. The GitVersionCore.Tests project seems to not use the common $(PackageVersion_YamlDotNet) I assume this was unintentional? This is generating a package version mismatch now as a result. 
This PR just changes 4.2.1 -> $(PackageVersion_YamlDotNet)

Sorry for missing this before, I should have done better diligence. I hope this build fares better. 

