### PR TITLE
Changed to MSBuild in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -26,7 +26,7 @@ void Build(string configuration, string nugetVersion, string semVersion, string 
     MSBuild("./src/GitVersion.sln", settings =>
 	{
 	 settings.SetConfiguration(configuration)
-        .SetVerbosity(Verbosity.Minimal)
+        .SetVerbosity(Verbosity.Normal)
         .WithTarget("Build")
         .WithProperty("POSIX",IsRunningOnUnix().ToString());
 		

--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,7 @@ string buildDir = "./build/";
 void Build(string configuration, string nugetVersion, string semVersion, string version, string preReleaseTag)
 {
 
-    DotNetBuild("./src/GitVersion.sln", settings =>
+    MSBuild("./src/GitVersion.sln", settings =>
 	{
 	 settings.SetConfiguration(configuration)
         .SetVerbosity(Verbosity.Minimal)

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="NSubstitute" Version="1.10.0.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <packagereference Include="NUnit3TestAdapter" Version="3.9.0"></packagereference>
-    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.0" />
     <PackageReference Include="YamlDotNet" Version="$(PackageVersion_YamlDotNet)" />  
   </ItemGroup>

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -20,12 +20,12 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -20,15 +20,15 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET461;NET461;NET461;NET461</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;RELEASE;NET461;RELEASE;NET461;RELEASE;NET461;RELEASE;NET461;RELEASE;NET461</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>  
   

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="NSubstitute" Version="1.10.0"></PackageReference>
     <PackageReference Include="NUnit" Version="3.9.0"></PackageReference>
     <packagereference Include="NUnit3TestAdapter" Version="3.9.0"></packagereference>
-    <PackageReference Include="Shouldly" Version="2.7.0"></PackageReference>
+    <PackageReference Include="Shouldly" Version="3.0.0"></PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GitVersion</RootNamespace>
     <AssemblyName>GitVersion</AssemblyName>
-    <TargetFrameworks>net40;netcoreapp20</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
     <BuildDir>$(SolutionDir)..\build\</BuildDir>
     
     <GenerateAssemblyFileVersionAttribute Condition="'$(GenerateAssemblyFileVersionAttribute)' == ''">false</GenerateAssemblyFileVersionAttribute>

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="NUnit" Version="3.9.0"></PackageReference>
     <packagereference Include="NUnit3TestAdapter" Version="3.9.0"></packagereference>
     <PackageReference Include="ObjectApproval" Version="1.3.0"></PackageReference>
-    <PackageReference Include="Shouldly" Version="2.7.0"></PackageReference>
+    <PackageReference Include="Shouldly" Version="3.0.0"></PackageReference>
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2"></PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1"></PackageReference>
   </ItemGroup>


### PR DESCRIPTION
The log complains that DotNetBuild is obsolete. XBuild says "xbuild tool is deprecated and will be removed in future updates, use msbuild instead".

I tried to test this setting up my on travis build, but couldn't get it to work, sorry. 😞 